### PR TITLE
Update WebViewViewController.swift

### DIFF
--- a/SmartCaptureDemo/UI/WebViewViewController.swift
+++ b/SmartCaptureDemo/UI/WebViewViewController.swift
@@ -89,6 +89,8 @@ final class WebViewViewController: UIViewController {
 
         let webConfiguration = WKWebViewConfiguration()
         webConfiguration.userContentController = contentController
+        webConfiguration.allowsInlineMediaPlayback = true   //Fix live broadcast screen
+        webConfiguration.mediaPlaybackRequiresUserAction = false //Fix live broadcast screen
         return webConfiguration
     }
 


### PR DESCRIPTION
Fix Live Broadcast, which opens a full native camera without a button to take a picture of the document.